### PR TITLE
Update to Alpine 3.19 and use the packaged musl-locales

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,6 @@
-FROM alpine:3.9
+FROM alpine:3.19
 
 # set our environment variable
 ENV MUSL_LOCPATH="/usr/share/i18n/locales/musl"
 
-# install libintl
-# then install dev dependencies for musl-locales
-# clone the sources
-# build and install musl-locales
-# remove sources and compile artifacts
-# lastly remove dev dependencies again
-RUN apk --no-cache add libintl && \
-	apk --no-cache --virtual .locale_build add cmake make musl-dev gcc gettext-dev git && \
-	git clone https://gitlab.com/rilian-la-te/musl-locales && \
-	cd musl-locales && cmake -DLOCALE_PROFILE=OFF -DCMAKE_INSTALL_PREFIX:PATH=/usr . && make && make install && \
-	cd .. && rm -r musl-locales && \
-	apk del .locale_build
+RUN apk --no-cache add libintl musl-locales

--- a/README.md
+++ b/README.md
@@ -28,15 +28,10 @@ Either use this image as a base, or copy the two steps from this dockerfile into
 
 ## Creating or modifying locales
 
-Per default, locales are maintained and pulled from https://gitlab.com/rilian-la-te/musl-locales.
-Currently, the selection of locales is very limited and incomplete, but you are welcome to create your own.
-To do so, clone that repository, modify the existing .po files or create a new one.
-
-Then, you can:
-
-- test your new creations by changing the repository address inside the Dockerfile to your own clone
-- make a merge request upstream
+Locales for Alpine Linux are maintained on https://git.adelielinux.org/adelie/musl-locales (fork of https://gitlab.com/rilian-la-te/musl-locales). Currently, the selection of locales is limited and incomplete, but you are welcome to create and contribute your own, you can find more info on that repo.
 
 # Credits
 
-Konstantin from https://gitlab.com/rilian-la-te/musl-locales for the locale program.
+* Konstantin for the original program: https://gitlab.com/rilian-la-te/musl-locales
+* Adelie Linux for the fork
+* Alpine Linux for the packaging


### PR DESCRIPTION
Now that `musl-locales` is [packaged for Alpine](https://pkgs.alpinelinux.org/package/v3.19/main/x86_64/musl-locales) (since 3.12), this image can be simplified